### PR TITLE
Upstream poetry patches

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -926,4 +926,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "<3.13,>=3.8"
-content-hash = "17945116c128df91f22ca39551f92cc097518572568f0dfa49b300aa5e2cb1c4"
+content-hash = "73fd025e3c8466fb90c66a08f62964fc0bba7eb930c73b82c43824d3373c1ce6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,10 @@ authors = [
     "Maxim Mityutko <m@brhd.io>",
     "Dani Hodovic <dani.hodovic@gmail.com>"
 ]
+packages = [{include = "src"}]
+
+[tool.poetry.scripts]
+borgmatic-exporter = 'src.cli:cli'
 
 [tool.poetry.dependencies]
 python = "<3.13,>=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ borgmatic-exporter = 'src.cli:cli'
 
 [tool.poetry.dependencies]
 python = "<3.13,>=3.8"
-prometheus-client = "^0.19.0"
+prometheus-client = "<0.21.0,>=0.19.0"
 click = "^8.1.7"
 pretty-errors = "^1.2.19"
 loguru = "^0.7.2"
 Flask = "^3.0.0"
-waitress = "^2.1.2"
+waitress = "<4.0.0,>=2.1.2"
 arrow = "^1.3.0"
 timy = "^0.4.2"
 


### PR DESCRIPTION
Upstream patches necessary for packaging for Nix: https://github.com/NixOS/nixpkgs/pull/290452

Feel free to drop the second commit.
Nixpkgs provides a newer version of the packages, which is why looser constraints are required.
