### PR TITLE
allow define borgmatic image version at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ghcr.io/borgmatic-collective/borgmatic:1.8.13
+ARG BORGMATIC_IMAGE_VERSION="latest"
+FROM ghcr.io/borgmatic-collective/borgmatic:${BORGMATIC_IMAGE_VERSION}
 
 LABEL org.opencontainers.image.source="https://github.com/maxim-mityutko/borgmatic-exporter"
-LABEL org.opencontainers.image.base.name="borgmatic:1.8.13"
+LABEL org.opencontainers.image.base.name="borgmatic:${BORGMATIC_IMAGE_VERSION}"
 LABEL org.opencontainers.image.title="Borgmatic Exporter"
 LABEL org.opencontainers.image.description="Official Borgmatic image bundled with the Prometheus exporter"
 


### PR DESCRIPTION
allow define borgmatic image version at build time.
This allows to not have to edit Dockerfie when building for a new borgmatic version.