### PR TITLE
[feature] Add archive specific metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ however it introduces a few changes:
 - native integration with the official Borgmatic docker image
 
 ## Metrics
-| Name                                    | Type  |
-|-----------------------------------------|-------|
-| borg_total_backups                      | Gauge |
-| borg_total_chunks                       | Gauge |
-| borg_total_size                         | Gauge |
-| borg_total_compressed_size              | Gauge |
-| borg_total_deduplicated_size            | Gauge |
-| borg_total_deduplicated_compressed_size | Gauge |
-| borg_last_backup_timestamp              | Gauge |
+| Name                                          | Type  |
+|-----------------------------------------------|-------|
+| borg_total_backups                            | Gauge |
+| borg_total_chunks                             | Gauge |
+| borg_total_size                               | Gauge |
+| borg_total_compressed_size                    | Gauge |
+| borg_total_deduplicated_size                  | Gauge |
+| borg_total_deduplicated_compressed_size       | Gauge |
+| borg_last_backup_timestamp                    | Gauge |
+| borg_last_backup_duration                     | Gauge |
+| borg_last_backup_files                        | Gauge |
+| borg_last_backup_deduplicated_compressed_size | Gauge |
+| borg_last_backup_compressed_size              | Gauge |
+| borg_last_backup_size                         | Gauge |
 
 ## Installation
 ### Docker

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -2,8 +2,8 @@
 import json
 import os
 import subprocess
-from io import StringIO
 from functools import partial
+from io import StringIO
 from typing import Any
 
 import arrow
@@ -57,6 +57,41 @@ def create_metrics(registry):
     Gauge(
         "borg_last_backup_timestamp",
         "Timestamp of the last Borg backup",
+        ["repository"],
+        registry=registry,
+    )
+
+    Gauge(
+        "borg_last_backup_duration",
+        "Duration of the last Borg backup",
+        ["repository"],
+        registry=registry,
+    )
+
+    Gauge(
+        "borg_last_backup_files",
+        "Amount of files contained in the last Borg backup",
+        ["repository"],
+        registry=registry,
+    )
+
+    Gauge(
+        "borg_last_backup_deduplicated_compressed_size",
+        "Size of the deduplicated and compressed last Borg backup",
+        ["repository"],
+        registry=registry,
+    )
+
+    Gauge(
+        "borg_last_backup_compressed_size",
+        "Size of the compressed last Borg backup",
+        ["repository"],
+        registry=registry,
+    )
+
+    Gauge(
+        "borg_last_backup_size",
+        "Size of the last Borg backup",
         ["repository"],
         registry=registry,
     )
@@ -141,8 +176,9 @@ def collect(borgmatic_configs: list, registry):
         )
 
         if r.get("archives") and len(r["archives"]) > 0:
-            # Last Backup Timestamp
             latest_archive = r["archives"][-1]
+
+            # Last Backup Timestamp
             set_metric(
                 registry=registry,
                 metric="borg_last_backup_timestamp",
@@ -150,6 +186,46 @@ def collect(borgmatic_configs: list, registry):
                 value=arrow.get(latest_archive["end"])
                 .replace(tzinfo="local")
                 .timestamp(),
+            )
+
+            # Last Backup Duration
+            set_metric(
+                registry=registry,
+                metric="borg_last_backup_duration",
+                labels=labels,
+                value=latest_archive["duration"],
+            )
+
+            # Last Backup number of files
+            set_metric(
+                registry=registry,
+                metric="borg_last_backup_files",
+                labels=labels,
+                value=latest_archive["stats"]["nfiles"],
+            )
+
+            # Last Backup Deduplicated Compressed Size
+            set_metric(
+                registry=registry,
+                metric="borg_last_backup_deduplicated_compressed_size",
+                labels=labels,
+                value=latest_archive["stats"]["deduplicated_size"],
+            )
+
+            # Last Backup Compressed Size
+            set_metric(
+                registry=registry,
+                metric="borg_last_backup_compressed_size",
+                labels=labels,
+                value=latest_archive["stats"]["compressed_size"],
+            )
+
+            # Last Backup Size
+            set_metric(
+                registry=registry,
+                metric="borg_last_backup_size",
+                labels=labels,
+                value=latest_archive["stats"]["original_size"],
             )
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -50,6 +50,11 @@ class TestMetrics:
         assert "borg_total_deduplicated_compressed_size" in result
         assert "borg_total_deduplicated_size" in result
         assert "borg_last_backup_timestamp" in result
+        assert "borg_last_backup_duration" in result
+        assert "borg_last_backup_files" in result
+        assert "borg_last_backup_deduplicated_compressed_size" in result
+        assert "borg_last_backup_compressed_size" in result
+        assert "borg_last_backup_size" in result
 
     @pytest.mark.parametrize(
         "metric, repo, expect",
@@ -62,6 +67,24 @@ class TestMetrics:
             ("borg_total_deduplicated_compressed_size", "/borg/backup-1", 537932015.0),
             ("borg_total_deduplicated_size", "/borg/backup-1", 1296544339.0),
             ("borg_total_deduplicated_size", "/borg/backup-2", 21296544339.0),
+            ("borg_last_backup_duration", "/borg/backup-1", 107.499993),
+            ("borg_last_backup_duration", "/borg/backup-2", 117.189547),
+            ("borg_last_backup_files", "/borg/backup-1", 11),
+            ("borg_last_backup_files", "/borg/backup-2", 12),
+            (
+                "borg_last_backup_deduplicated_compressed_size",
+                "/borg/backup-1",
+                10351331,
+            ),
+            (
+                "borg_last_backup_deduplicated_compressed_size",
+                "/borg/backup-2",
+                18718565,
+            ),
+            ("borg_last_backup_compressed_size", "/borg/backup-1", 379050627),
+            ("borg_last_backup_compressed_size", "/borg/backup-2", 419966002),
+            ("borg_last_backup_size", "/borg/backup-1", 807712494),
+            ("borg_last_backup_size", "/borg/backup-2", 893501335),
         ],
     )
     def test_individual_metrics(self, collect, metric, repo, expect):


### PR DESCRIPTION
They are basically free, as already provided by the actual command results.
I find them actually much more interesting than the current sizes of the whole repo... as they allow to conclude to some potential problems or trends... 
i.e. : 
 - compare archive file counts.... if they differ extrem ... someone deleted everything by accident or by malicious code.
 - allow to track data increase, compression and deduplication a bit different. Per archive can give different insights.
 - duration changes can also show potential problems.

for sure, this metrics only makes sense if you have one repo per backup and the archives represents snapshots of the same data.... but this was anyway a assumption for using last archive data per repo i.e. in `borg_last_backup_timestamp`.

Sorry for not providing the actual dashboard to this metrics, as I didn't had time to make them proper for the PR.