### PR TITLE
[fix] Minor changes to Grafana dashboard

### DIFF
--- a/observability/grafana-dashboard.json
+++ b/observability/grafana-dashboard.json
@@ -1247,9 +1247,9 @@
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "instant": false,
+              "instant": true,
               "legendFormat": "{{repository}}",
-              "range": true,
+              "range": false,
               "refId": "A",
               "useBackend": false
             }

--- a/observability/grafana-dashboard.json
+++ b/observability/grafana-dashboard.json
@@ -848,7 +848,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "sum by(repository, instance) (borg_total_backups{instance=~\"$INSTANCE\", repository=~\"$REPOSITORY\"})",
+              "expr": "sum by(repository) (borg_total_backups{instance=~\"$INSTANCE\", repository=~\"$REPOSITORY\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -1243,7 +1243,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "time() - min by(instance, repository) (borg_last_backup_timestamp{instance=~\"$INSTANCE\", repository=~\"${REPOSITORY:raw}\"})",
+              "expr": "time() - max by(repository) (borg_last_backup_timestamp{instance=~\"$INSTANCE\", repository=~\"${REPOSITORY:raw}\"})",
               "format": "time_series",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
@@ -1947,7 +1947,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
- repo level metrics `Backup Count` and `Since Last Backup` should only be grouped on repo level, ignoring instance
- repo level metric `Since Last Backup` now matches the table level metric in the overview